### PR TITLE
Leave normal page layout intact

### DIFF
--- a/latex/ugent2016-en.tex
+++ b/latex/ugent2016-en.tex
@@ -421,6 +421,15 @@ Packages such as \texttt{ugent2016-title} use these basic building blocks to det
 \includegraphics[width=3\smallblock]{\ugentkortrijk}
 \end{minted}
 
+\section{Other packages}
+
+This package should work togheter well with other packages.
+However, there are some points worth mentioning:
+
+\begin{itemize}
+\item The title page uses the \texttt{geometry} package, with the option \texttt{pass}. This means it should work togheter with KomaScript for example, but special attention is recommended.
+\end{itemize}
+
 \appendix
 
 \section{Title page type \texttt{course}}\label{sec:voorblad-met-stijl-course}

--- a/latex/ugent2016-nl.tex
+++ b/latex/ugent2016-nl.tex
@@ -431,6 +431,15 @@ Dit zijn lengtes en kunnen dus overal gebruikt worden waar lengtes toegelaten wo
 \includegraphics[width=3\smallblock]{\ugentkortrijk}
 \end{minted}
 
+\section{Andere pakketten}
+
+Dit pakket werkt normaal goed samen met andere pakketten.
+Toch zijn er soms zaken waar rekening mee gehouden moet worden:
+
+\begin{itemize}
+\item Het voorblad gebruikt het pakket \texttt{geometry}, met de optie \texttt{pass}. Dat betekent dat het kan samenwerken met bijvoorbeeld KomaScript, maar aandachtig zijn is geboden.
+\end{itemize}
+
 \appendix
 
 \section{Voorblad met stijl \texttt{course}}\label{sec:voorblad-met-stijl-course}

--- a/latex/ugent2016-title.sty
+++ b/latex/ugent2016-title.sty
@@ -39,7 +39,9 @@
 	% Used for including images
 	\RequirePackage{graphicx}
 	% Used to adjust margins of the title page
+	\PassOptionsToPackage{pass}{geometry}
 	\RequirePackage{geometry}
+	% Fix compat with KomaScript
 	% Sets the spacing between lines.
 	\RequirePackage{setspace}
 	% Used for underlining the titles


### PR DESCRIPTION
By setting `pass`, we no longer change the page layout of other pages besides the title page. This is necessary for KOMAScript, for example.

Specifically for KOMAScript we could also set `usegeometry`, but that will only fix stuff for KOMAScript. If there are other packages out there, this won't do anything, while `pass` should have effect on all packages.